### PR TITLE
Improve .cspoj file and Directory.Build.props file

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,7 @@
 		<Copyright>Copyright © 2022-$([System.DateTime]::UtcNow.Year) $(Company)</Copyright>
 		<Description>$(PluginName) description.</Description>
 		<PackageIcon />
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/$(Company)/$(PluginName)</PackageProjectUrl>
 		<PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
 		<RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,4 +39,8 @@
 		<PublicSign>false</PublicSign>
 		<SignAssembly>true</SignAssembly>
 	</PropertyGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="JustArchiNET.Madness" IncludeAssets="compile" />
+	</ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,10 +11,9 @@
 		<ApplicationIcon />
 		<Authors>YourName</Authors>
 		<Company>$(Authors)</Company>
-		<Copyright>Copyright © 2021-$([System.DateTime]::UtcNow.Year) $(Company)</Copyright>
+		<Copyright>Copyright © 2022-$([System.DateTime]::UtcNow.Year) $(Company)</Copyright>
 		<Description>$(PluginName) description.</Description>
 		<PackageIcon />
-		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/$(Company)/$(PluginName)</PackageProjectUrl>
 		<PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
 		<RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,5 +42,21 @@
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
 		<PackageReference Include="JustArchiNET.Madness" IncludeAssets="compile" />
+
+		<Using Include="JustArchiNET.Madness" />
+		<Using Include="JustArchiNET.Madness.ArgumentNullExceptionMadness.ArgumentNullException" Alias="ArgumentNullException" />
+		<Using Include="JustArchiNET.Madness.ArrayMadness.Array" Alias="Array" />
+		<Using Include="JustArchiNET.Madness.ConvertMadness.Convert" Alias="Convert" />
+		<Using Include="JustArchiNET.Madness.EnumMadness.Enum" Alias="Enum" />
+		<Using Include="JustArchiNET.Madness.EnvironmentMadness.Environment" Alias="Environment" />
+		<Using Include="JustArchiNET.Madness.FileMadness.File" Alias="File" />
+		<Using Include="JustArchiNET.Madness.HashCodeMadness.HashCode" Alias="HashCode" />
+		<Using Include="JustArchiNET.Madness.HMACSHA1Madness.HMACSHA1" Alias="HMACSHA1" />
+		<Using Include="JustArchiNET.Madness.OperatingSystemMadness.OperatingSystem" Alias="OperatingSystem" />
+		<Using Include="JustArchiNET.Madness.PathMadness.Path" Alias="Path" />
+		<Using Include="JustArchiNET.Madness.RandomMadness.Random" Alias="Random" />
+		<Using Include="JustArchiNET.Madness.SHA256Madness.SHA256" Alias="SHA256" />
+		<Using Include="JustArchiNET.Madness.SHA512Madness.SHA512" Alias="SHA512" />
+		<Using Include="JustArchiNET.Madness.StringMadness.String" Alias="String" />
 	</ItemGroup>
 </Project>

--- a/MyAwesomePlugin/MyAwesomePlugin.csproj
+++ b/MyAwesomePlugin/MyAwesomePlugin.csproj
@@ -9,10 +9,6 @@
 		<PackageReference Include="System.Composition.AttributedModel" IncludeAssets="compile" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-		<PackageReference Include="JustArchiNET.Madness" IncludeAssets="compile" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\ArchiSteamFarm\ArchiSteamFarm\ArchiSteamFarm.csproj" ExcludeAssets="all" Private="false" />
 	</ItemGroup>


### PR DESCRIPTION
## Changes

- Copyright in `Directory.Build.Props` is updated. A plugin that is created in the year 2022 should not have a copyright notice starting in the year 2021
- `JustArchiNET.Madness` is now included the same way it is done over in ASFs main repository.
- Removed license expression. A plugin maintainer should be able to decide themselves, which licence their project is using.