### PR TITLE
Get rid of ad-m/github-push-action

### DIFF
--- a/.github/workflows/bump-asf-reference.yml
+++ b/.github/workflows/bump-asf-reference.yml
@@ -59,7 +59,7 @@ jobs:
             exit
         fi
 
-        git config --global --add safe.directory $(pwd)
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
         git config -f .gitmodules submodule.ArchiSteamFarm.branch "$LATEST_ASF_RELEASE"
 

--- a/.github/workflows/bump-asf-reference.yml
+++ b/.github/workflows/bump-asf-reference.yml
@@ -59,6 +59,8 @@ jobs:
             exit
         fi
 
+        git config --global --add safe.directory $(pwd)
+
         git config -f .gitmodules submodule.ArchiSteamFarm.branch "$LATEST_ASF_RELEASE"
 
         git add -A ".gitmodules"
@@ -73,8 +75,4 @@ jobs:
 
         git commit -m "Automatic ArchiSteamFarm reference update to ${LATEST_ASF_RELEASE}"
 
-    - name: Push changes to the repo
-      uses: ad-m/github-push-action@v0.8.0
-      with:
-        github_token: ${{ env.PUSH_GITHUB_TOKEN }}
-        branch: ${{ github.ref }}
+        git push


### PR DESCRIPTION
## Pull request

## Changes

I removed **ad-m/github-push-action**, because it causes issues in private github repositories (at least for me), but I believe this change is also good because it removes unnecessary layers of abstraction and dependency upon additional reusable action made by third party, so it should improve both performance and security. 
I tested it in my private repo, and it seems to work as intended.
Please consider merging this pull request.